### PR TITLE
feat: Add ModelsLab provider for image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ A unified, driver-based Laravel toolkit for working with multiple LLM providers 
 | **OpenAI** | `openai` | Yes | Yes | Yes |
 | **Anthropic** | `anthropic` | Yes | - | Yes |
 | **LM Studio** | `lmstudio` | Yes | - | Yes |
+| **ModelsLab** | `modelslab` | - | Yes | - |
 | **Dummy** | `dummy` | Yes | Yes | - |
 
 - **OpenAI** - GPT-4, GPT-4.1, DALL-E 3, and other OpenAI models
 - **Anthropic** - Claude 3.5 Sonnet, Claude 3 Opus, and other Claude models
 - **LM Studio** - Run any open-source LLM locally (Llama, Mistral, Phi, etc.)
+- **ModelsLab** - Flux, SDXL, Stable Diffusion, and 10,000+ community models for image generation
 - **Dummy** - For testing and offline development (returns configurable mock responses)
 
 ## Requirements

--- a/config/llm-suite.php
+++ b/config/llm-suite.php
@@ -54,6 +54,13 @@ return [
             'timeout' => env('LMSTUDIO_TIMEOUT', 120), // Local models can be slow
         ],
 
+        'modelslab' => [
+            'driver' => 'modelslab',
+            'api_key' => env('MODELSLAB_API_KEY'),
+            'image_model' => env('MODELSLAB_IMAGE_MODEL', 'flux'),
+            'timeout' => env('MODELSLAB_TIMEOUT', 120),
+        ],
+
         'dummy' => [
             'driver' => 'dummy',
             // Optional: set default responses for testing

--- a/src/Clients/ModelsLab/ModelsLabClient.php
+++ b/src/Clients/ModelsLab/ModelsLabClient.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oziri\LlmSuite\Clients\ModelsLab;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Oziri\LlmSuite\Contracts\ImageClient;
+use Oziri\LlmSuite\Contracts\LlmClient;
+use Oziri\LlmSuite\Exceptions\ProviderRequestException;
+use Oziri\LlmSuite\Support\ImageResponse;
+
+/**
+ * ModelsLab API client implementation.
+ * Supports text-to-image generation using Flux and Stable Diffusion models.
+ *
+ * @see https://docs.modelslab.com/image-generation/overview
+ */
+class ModelsLabClient implements ImageClient
+{
+    /**
+     * Base URL for ModelsLab API.
+     */
+    protected const BASE_URL = 'https://modelslab.com/api/v6';
+
+    /**
+     * API endpoint for text-to-image generation.
+     */
+    protected const ENDPOINT_TEXT2IMG = '/images/text2img';
+
+    /**
+     * Default image model.
+     */
+    protected const DEFAULT_MODEL = 'flux';
+
+    /**
+     * Default image size.
+     */
+    protected const DEFAULT_SIZE = '1024x1024';
+
+    /**
+     * Error message for failed image generation requests.
+     */
+    protected const ERROR_IMAGE_FAILED = 'ModelsLab image generation request failed';
+
+    public function __construct(
+        protected array $config
+    ) {}
+
+    /**
+     * Get a configured HTTP client for ModelsLab API requests.
+     */
+    protected function http(): PendingRequest
+    {
+        return Http::baseUrl(self::BASE_URL)
+            ->acceptJson()
+            ->asJson()
+            ->timeout($this->config['timeout'] ?? 120);
+    }
+
+    /**
+     * Generate an image using ModelsLab API.
+     *
+     * Supported params:
+     *   - prompt (required): Text description of the image to generate
+     *   - model (optional): Model ID (default: 'flux'). Options: flux, sdxl, etc.
+     *   - size (optional): Image size as 'WxH', e.g. '1024x1024' (default)
+     *   - negative_prompt (optional): What to exclude from the image
+     *   - num_inference_steps (optional): Steps for generation (default: 30)
+     *   - guidance_scale (optional): CFG scale (default: 7.5)
+     *   - seed (optional): Seed for reproducible results
+     *   - samples (optional): Number of images to generate (default: 1)
+     */
+    public function generate(array $params): ImageResponse
+    {
+        [$width, $height] = $this->parseSize($params['size'] ?? self::DEFAULT_SIZE);
+
+        $payload = [
+            'key'                  => $this->config['api_key'],
+            'prompt'               => $params['prompt'] ?? '',
+            'model_id'             => $params['model'] ?? $this->config['image_model'] ?? self::DEFAULT_MODEL,
+            'width'                => (string) $width,
+            'height'               => (string) $height,
+            'samples'              => (string) ($params['samples'] ?? 1),
+            'num_inference_steps'  => (string) ($params['num_inference_steps'] ?? 30),
+            'guidance_scale'       => $params['guidance_scale'] ?? 7.5,
+            'safety_checker'       => 'no',
+        ];
+
+        if (! empty($params['negative_prompt'])) {
+            $payload['negative_prompt'] = $params['negative_prompt'];
+        }
+
+        if (isset($params['seed'])) {
+            $payload['seed'] = $params['seed'];
+        }
+
+        $response = $this->http()->post(self::ENDPOINT_TEXT2IMG, $payload);
+
+        if (! $response->successful()) {
+            throw ProviderRequestException::fromResponse(self::ERROR_IMAGE_FAILED, $response);
+        }
+
+        $data = $response->json();
+
+        if (($data['status'] ?? '') === 'error') {
+            throw new \RuntimeException(
+                'ModelsLab API error: '.($data['message'] ?? $data['messege'] ?? 'Unknown error')
+            );
+        }
+
+        $imageUrl = $data['output'][0] ?? null;
+
+        return new ImageResponse(
+            url: $imageUrl,
+            raw: $data,
+        );
+    }
+
+    /**
+     * ModelsLab does not support chat completions.
+     */
+    public function isAvailable(): bool
+    {
+        try {
+            $response = $this->http()->post('/images/text2img', [
+                'key' => $this->config['api_key'],
+                'prompt' => 'test',
+                'model_id' => self::DEFAULT_MODEL,
+                'width' => '64',
+                'height' => '64',
+                'samples' => '1',
+                'num_inference_steps' => '1',
+            ]);
+
+            return $response->successful();
+        } catch (\Exception) {
+            return false;
+        }
+    }
+
+    /**
+     * ModelsLab does not expose a public model listing endpoint via this SDK.
+     */
+    public function getAvailableModels(): array
+    {
+        return [
+            'flux',
+            'flux-dev',
+            'sdxl',
+            'realistic-vision-v6',
+            'dreamshaper-8',
+            'anything-v5',
+        ];
+    }
+
+    /**
+     * Parse a size string like "1024x1024" into [width, height].
+     */
+    protected function parseSize(string $size): array
+    {
+        $parts = explode('x', $size, 2);
+
+        return [
+            (int) ($parts[0] ?? 1024),
+            (int) ($parts[1] ?? 1024),
+        ];
+    }
+}

--- a/src/Managers/LlmManager.php
+++ b/src/Managers/LlmManager.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Oziri\LlmSuite\Clients\Anthropic\AnthropicClient;
 use Oziri\LlmSuite\Clients\Dummy\DummyClient;
 use Oziri\LlmSuite\Clients\LmStudio\LmStudioClient;
+use Oziri\LlmSuite\Clients\ModelsLab\ModelsLabClient;
 use Oziri\LlmSuite\Clients\OpenAI\OpenAIClient;
 use Oziri\LlmSuite\Contracts\ChatClient;
 use Oziri\LlmSuite\Contracts\ConversationStore;
@@ -177,6 +178,7 @@ class LlmManager
             'openai' => $this->createOpenAiClient($config),
             'anthropic' => $this->createAnthropicClient($config),
             'lmstudio' => $this->createLmStudioClient($config),
+            'modelslab' => $this->createModelsLabClient($config),
             'dummy' => $this->createDummyClient($config),
             default => throw ProviderConfigException::unsupportedDriver($driver ?? 'null'),
         };
@@ -204,6 +206,14 @@ class LlmManager
     protected function createLmStudioClient(array $config): LmStudioClient
     {
         return new LmStudioClient($config);
+    }
+
+    /**
+     * Create a ModelsLab client instance.
+     */
+    protected function createModelsLabClient(array $config): ModelsLabClient
+    {
+        return new ModelsLabClient($config);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds [ModelsLab](https://modelslab.com) as a new image generation driver, giving Laravel developers access to Flux, SDXL, Stable Diffusion, and 10,000+ community models through the existing unified API.

## What this PR adds

### `ModelsLabClient` (`src/Clients/ModelsLab/ModelsLabClient.php`)
- Implements `ImageClient` interface — exactly the same contract as the OpenAI image client
- Supports all standard params: `prompt`, `model`, `size`, `negative_prompt`, `num_inference_steps`, `guidance_scale`, `seed`, `samples`
- Handles the ModelsLab API response format (`status` + `output[]`)

### Driver registration (`LlmManager.php`)
- Adds `modelslab` to the driver match statement

### Config example (`config/llm-suite.php`)
```php
'modelslab' => [
    'driver'       => 'modelslab',
    'api_key'      => env('MODELSLAB_API_KEY'),
    'image_model'  => env('MODELSLAB_IMAGE_MODEL', 'flux'),
    'timeout'      => env('MODELSLAB_TIMEOUT', 120),
],
```

### README update
- Adds ModelsLab row to the supported providers table

## Usage

```php
// .env
MODELSLAB_API_KEY=your-api-key

// Generate image
$response = Llm::using('modelslab')->image([
    'prompt'               => 'A sunset over mountains in watercolor style',
    'model'                => 'flux',    // or sdxl, realistic-vision-v6, etc.
    'size'                 => '1024x1024',
    'negative_prompt'      => 'blurry, low quality',
    'num_inference_steps'  => 30,
]);

echo $response->url; // Direct CDN URL to the generated image
```

## Available models
- `flux` (default) — High-quality photorealistic generation
- `sdxl` — Stable Diffusion XL
- `realistic-vision-v6` — Photorealistic portraits
- `dreamshaper-8` — Artistic/creative styles
- `anything-v5` — Anime/illustration style
- …and thousands more at [modelslab.com/models](https://modelslab.com/models)

## Resources
- [ModelsLab API docs](https://docs.modelslab.com/image-generation/overview)
- [Get API key (free tier available)](https://modelslab.com/dashboard/api-keys)
